### PR TITLE
Add TypeScript definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,4 @@
 /**
  * Check if something is a generator function.
- *
- * @param fn - The value to check.
- * @returns Returns true if fn is generator function, else false.
  */
-export default function isGeneratorFn (fn: any): fn is GeneratorFunction;
+export default function isGeneratorFn(value: unknown): value is GeneratorFunction;

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Check if something is a generator function.
+ *
+ * @param fn - The value to check.
+ * @returns Returns true if fn is generator function, else false.
+ */
+export default function isGeneratorFn (fn: any): fn is GeneratorFunction;

--- a/index.js
+++ b/index.js
@@ -9,3 +9,5 @@ module.exports = fn => {
 	return (fn.constructor && fn.constructor.name === 'GeneratorFunction') ||
 		toString.call(fn) === '[object GeneratorFunction]';
 };
+
+module.exports.default = module.exports;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,0 +1,11 @@
+import {expectType} from 'tsd-check';
+import isGeneratorFn from '.';
+
+expectType<boolean>(isGeneratorFn(function * () {}));
+expectType<boolean>(isGeneratorFn(function * () {
+	yield 'unicorn';
+}));
+expectType<boolean>(isGeneratorFn(null));
+expectType<boolean>(isGeneratorFn(undefined));
+expectType<boolean>(isGeneratorFn(() => {}));
+expectType<boolean>(isGeneratorFn(''));

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
 		"node": ">=6"
 	},
 	"scripts": {
-		"test": "xo && ava"
+		"test": "xo && ava && tsd-check"
 	},
 	"files": [
-		"index.js"
+		"index.js",
+		"index.d.ts"
 	],
 	"keywords": [
 		"generator",
@@ -31,6 +32,7 @@
 	],
 	"devDependencies": {
 		"ava": "^1.0.1",
+		"tsd-check": "^0.2.1",
 		"xo": "^0.23.0"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
 	],
 	"devDependencies": {
 		"ava": "^1.0.1",
-		"tsd-check": "^0.2.1",
+		"tsd-check": "^0.3.0",
 		"xo": "^0.23.0"
 	}
 }


### PR DESCRIPTION
- [x] Use tab-indentation and semicolons.
- [x] The definition should target the latest TypeScript version.
- [x] Exported properties/methods should be documented (see below).
- [x] The definition should be tested (see below).
- [x] Ensure you're not falling for any of the common mistakes.
- [x] For packages with a default export, use export default foo;, not export = foo;. You will have to add module.exports.default = foo; to the index.js file.
- [x] If the entry file in the package is named index.js, name the type definition file index.d.ts and put it in root.
- [x] You don't need to add a typings field to package.json as TypeScript will infer it from the name.
- [x] Add the type definition file to the files field in package.json.
- [x] The pull request should have the title Add TypeScript definition. (Copy-paste it so you don't get it wrong)
- [ ] Ignore any Travis linting failures. I will fix them after merging.
- [ ] Help review other pull requests that adds a type definition.
